### PR TITLE
adding a replace_erbs task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Getting Started
           ...
         end
 
-2. Run `rake haml:convert_erbs`
+2. Run `rake haml:convert_erbs` to convert your ERB files without removing them, or run `rake haml:replace_erbs` to convert and replace your ERB files to your new HAML files.
 3. Watch your ERB files getting converted to haml.
 
 And that's it!

--- a/lib/erb2haml/railties/erb2haml.rake
+++ b/lib/erb2haml/railties/erb2haml.rake
@@ -40,5 +40,43 @@ namespace :haml do
       end
     end
   end #End rake task
+
+  desc "Perform bulk conversion of all html.erb files to Haml in views folder, then remove the converted html.erb files."
+  task :replace_erbs do
+    if `which html2haml`.empty?
+      puts "#{color "ERROR: ", RED_FG} Could not find " +
+         "#{color "html2haml", GREEN_FG} in your PATH. Aborting."
+      exit(false)
+    end
+
+    puts "Looking for #{color "ERB", GREEN_FG} files to convert to " +
+      "#{color("Haml", RED_FG)}..."
+
+    Find.find("app/views/") do |path|
+      if FileTest.file?(path) and path.downcase.match(/\.html\.erb$/i)
+        haml_path = path.slice(0...-3)+"haml"
+
+        unless FileTest.exists?(haml_path)
+          print "Converting: #{path}... "
+
+          if system("html2haml", path, haml_path)
+            puts color("Done!", GREEN_FG)
+            print "Removing: #{path}... "
+            if system("rm", path)
+              puts color("Removed!", GREEN_FG)
+            else
+              puts color("Failed!", RED_FG)
+            end
+          else
+            puts color("Failed!", RED_FG)
+          end
+
+        end
+
+      end
+
+    end
+  end #End rake task
+
 end # End of :haml namespace
 


### PR DESCRIPTION
When converting erb files to haml files, the erb files will stay in the same place, instead this task gives the users a choice to remove the already converted erb files.
