### PR TITLE
html2haml is required for haml >= 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ _or_ if you prefer the block syntax
       # ... 
     end
 
+If you use haml version 4.0 or over (>= 4.0), you need to add `html2haml` as well
+
+    `gem "html2haml", :group => :development`
+
+
 ### Converting ERB Templates to Haml
 
 After enabling the rake tasks, you can convert your ERB templates to


### PR DESCRIPTION
html2haml is required for haml 4

Error will occur without it. 'html2haml is not part of the bundle. Add it to Gemfile. (Gem::LoadError)'
