### PR TITLE
Add license to gemspec

### DIFF
--- a/erb2haml.gemspec
+++ b/erb2haml.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.email               = [ "david@davidslab.com" ]
   s.authors             = [ "David Leung" ]
   s.platform            = Gem::Platform::RUBY
+  s.license             = 'MIT'
 
   s.files               = %w[Gemfile Rakefile]
   s.files              += Dir.glob("{lib}/**/*")


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.